### PR TITLE
Add missing auth-httplib2 dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,7 @@ outputs:
         - cachetools >=3.1.0,<5
         - google-apitools >=0.5.31,<0.5.32
         - google-auth >=1.18.0,<2
-        - google-auth-httplib2>=0.1.0,<0.2.0
+        - google-auth-httplib2 >=0.1.0,<0.2.0
         - google-cloud-datastore >=1.8.0,<2
         - google-cloud-pubsub >=0.39.0,<2
         - google-cloud-bigquery >=1.6.0,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,7 +106,7 @@ outputs:
       run:
         - python
         - {{ pin_subpackage(name, max_pin='x.x.x.x.x.x') }}
-        # Try match what's in https://github.com/apache/beam/blob/master/sdks/python/setup.py#L261
+        # Try match what's in https://github.com/apache/beam/blob/v{{ version }}/sdks/python/setup.py#L268
         - cachetools >=3.1.0,<5
         - google-apitools >=0.5.31,<0.5.32
         - google-auth >=1.18.0,<2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win or py>=310]
-  number: 0
+  number: 1
 
 requirements:
   host:
@@ -106,9 +106,11 @@ outputs:
       run:
         - python
         - {{ pin_subpackage(name, max_pin='x.x.x.x.x.x') }}
+        # Try match what's in https://github.com/apache/beam/blob/master/sdks/python/setup.py#L261
         - cachetools >=3.1.0,<5
         - google-apitools >=0.5.31,<0.5.32
         - google-auth >=1.18.0,<2
+        - google-auth-httplib2>=0.1.0,<0.2.0
         - google-cloud-datastore >=1.8.0,<2
         - google-cloud-pubsub >=0.39.0,<2
         - google-cloud-bigquery >=1.6.0,<3


### PR DESCRIPTION
Beam doesn't try to authenticate to GCP without this -
see https://github.com/apache/beam/blob/0760f13c4a5ca1dcfa0e2fad7d875e2d2f050963/sdks/python/apache_beam/internal/gcp/auth.py#L29

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
