### PR TITLE
Pubsub dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win or py>=310]
-  number: 0
+  number: 1
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,6 +114,7 @@ outputs:
         - google-auth-httplib2 >=0.1.0,<0.2.0
         - google-cloud-datastore >=1.8.0,<2
         - google-cloud-pubsub >=2.1.0,<3
+        - google-cloud-pubsublite >=1.2.0,<2
         - google-cloud-bigquery >=1.6.0,<3
         - google-cloud-bigquery-storage >=2.6.3,<2.14
         - google-cloud-core >=0.28.1,<3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -113,7 +113,7 @@ outputs:
         - google-auth >=1.18.0,<2
         - google-auth-httplib2 >=0.1.0,<0.2.0
         - google-cloud-datastore >=1.8.0,<2
-        - google-cloud-pubsub >=0.39.0,<2
+        - google-cloud-pubsub >=2.1.0,<3
         - google-cloud-bigquery >=1.6.0,<3
         - google-cloud-bigquery-storage >=2.6.3,<2.14
         - google-cloud-core >=0.28.1,<3


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Apache-Beam 2.41.0 needs [updated versions](https://github.com/apache/beam/blob/v2.41.0/sdks/python/setup.py#L278) of PubSub and PubSubLite. Beam 2.41.0 will try to serialise the PubSub message using [a new method ](https://github.com/apache/beam/blob/v2.41.0/sdks/python/apache_beam/io/gcp/pubsub.py#L181)which, compared to [the old method](https://github.com/apache/beam/blob/v2.34.0/sdks/python/apache_beam/io/gcp/pubsub.py#L153), will throw an AttributeError.
