### PR TITLE
Switch to `google-cloud-bigquery-core`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: true  # [win or py>=310]
-  number: 1
+  number: 2
 
 requirements:
   host:
@@ -115,7 +115,7 @@ outputs:
         - google-cloud-datastore >=1.8.0,<2
         - google-cloud-pubsub >=2.1.0,<3
         - google-cloud-pubsublite >=1.2.0,<2
-        - google-cloud-bigquery >=1.6.0,<3
+        - google-cloud-bigquery-core >=1.6.0,<3
         - google-cloud-bigquery-storage >=2.6.3,<2.14
         - google-cloud-core >=0.28.1,<3
         - google-cloud-bigtable >=0.31.1,<2


### PR DESCRIPTION
The `google-cloud-bigquery` conda-forge package also includes all the extras, which we don't need.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
